### PR TITLE
[Fix] external menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "menu-api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A menu API for WordPress",
   "main": "index.js",
   "scripts": {

--- a/src/interfaces/siteTree.ts
+++ b/src/interfaces/siteTree.ts
@@ -51,6 +51,8 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
 
     return {
         getParent(urlInstanceRestUrl: string, idChild:number): { [urlInstance : string]: WpMenu } {
+            const parsedUrl = new URL(urlInstanceRestUrl);
+            const path = parsedUrl.pathname + parsedUrl.search;
             const result: { [urlInstance: string]: WpMenu } = {};
             const parent = parents[urlInstanceRestUrl][idChild];//it could be undefined;
             if (parent === undefined) {
@@ -58,7 +60,7 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
                     const items = itemsByID[url];
                     for (const id in items) {
                         const item = itemsByID[url][id];
-                        if (item.object === "epfl-external-menu" && item.rest_url === urlInstanceRestUrl){
+                        if (item.object === "epfl-external-menu" && item.rest_url === path){
                             result[url] = itemsByID[url][item.menu_item_parent];
                             return result;
                         }

--- a/test/e2e/lists.ts
+++ b/test/e2e/lists.ts
@@ -1,9 +1,10 @@
 import 'mocha';
 import {assert, expect} from "chai";
 import {getMenuItems} from "../../src/menus/lists";
-import {configRefresh, initializeCachedMenus} from "../../src/menus/refresh";
+import {configRefresh, initializeCachedMenus, refreshFileMenu} from "../../src/menus/refresh";
 import {loadConfig} from "../../src/utils/configFileReader";
 import {configLinks} from "../../src/utils/links";
+import {configLogs} from "../../src/utils/logger";
 
 describe("End To End Menu", function() {
     beforeEach(function(done){
@@ -13,6 +14,7 @@ describe("End To End Menu", function() {
 
             configRefresh(config);
             configLinks(config);
+
             initializeCachedMenus(pathRefreshFile);
             done();
         } else {
@@ -20,82 +22,111 @@ describe("End To End Menu", function() {
         }
     });
     describe("Breadcrumb", function() {
-        it('has at least one parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/", "en", "breadcrumb").list;
+        it('website has at least one parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/",
+                "en", "breadcrumb", "page", "Systems updates feed",
+                "https://www.epfl.ch/campus/services/website/blog-page/",
+                "https://www.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
+            console.log(items);
             assert(items.length>1);
         });
-        it('has a specific parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/", "en", "breadcrumb").list;
+        it('website has Services & Resources as parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/",
+                "en", "breadcrumb", "page", "Systems updates feed",
+                "https://www.epfl.ch/campus/services/website/blog-page/",
+                "https://www.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
             expect(items.find(f => f.title=='Services &amp; Resources')).not.be.undefined;
         });
-        it('has a specific parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/", "en", "breadcrumb").list;
+        it('storage-of-documents has a specific parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/",
+                "en", "breadcrumb", "page", "",
+                "",
+                "https://www.epfl.ch/campus/services/en", "Data Storage Solutions").list;
             expect(items.find(f => f.title=='Services &amp; Resources')).not.be.undefined;
         });
-        it('has Campus as parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/", "en", "breadcrumb").list;
+        it('website has Campus as parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/",
+                "en", "breadcrumb", "page", "Systems updates feed",
+                "https://www.epfl.ch/campus/services/website/blog-page/",
+                "https://www.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
             expect(items.find(f => f.title=='Campus')).not.be.undefined;
         });
-        it('has Services&Resources as parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/", "en", "breadcrumb").list;
-            expect(items.find(f => f.title=='Services &amp; Resources')).not.be.undefined;
-        });
-        it('has Schools as parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/schools/sb/research/isic/platforms/it-and-data-management-platform/purchasing-procedure/", "en", "breadcrumb").list;
-            expect(items.find(f => f.url=='https://www.epfl.ch/schools/sb/en/home/')).not.be.undefined;
-        });
-        it('has no Lab parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/labs/en/laboratories/", "en", "breadcrumb").list;
+        it('laboratories has no Lab parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/labs/en/laboratories/",
+                "en", "breadcrumb", "page", "", "",
+                "", "").list;
             assert(items.length == 1);
         });
-        it('has Labs as parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/labs/alice/en/index-fr-html/", "en", "breadcrumb").list;
+        it('Alice has Labs as parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/labs/alice/en/index-fr-html/",
+                "en", "breadcrumb", "page", "", "",
+                "", "").list;
             assert(items.length == 2);
             expect(items.find(f => f.url == 'https://www.epfl.ch/labs/en/laboratories/')).not.be.undefined;
         });
-        it('has Student Assoc and campus as parents', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/en/all-associations/", "en", "breadcrumb").list;
+        it('all-associations has Student Assoc and campus as parents', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/en/all-associations/",
+                "en", "breadcrumb", "page", "", "",
+                "", "").list;
             expect(items.find(f => f.url == 'https://www.epfl.ch/campus/associations/en/student-associations/')).not.be.undefined;
             expect(items.find(f => f.url == 'https://www.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
         });
-        it('has Assoc as parent', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/spaceat/en/spaceyourservice/", "en", "breadcrumb").list;
+        it('spaceyourservice has Assoc as parent', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/spaceat/en/spaceyourservice/",
+                "en", "breadcrumb", "page", "", "",
+                "", "").list;
             assert(items.length == 4);
             expect(items.find(f => f.url == 'https://www.epfl.ch/campus/associations/list/en/all-associations/')).not.be.undefined;
         });
-        it('has campus in parents', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/adec/index-html/the-comitee/", "en", "breadcrumb").list;
+        it('adec assoc has campus in parents', async function() {
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/adec/index-html/the-comitee/",
+                "en", "breadcrumb", "page", "", "",
+                "", "").list;
             assert(items.length == 5);
             expect(items.find(f => f.url == 'https://www.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
         });
         it('has one list assoc item', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/en/all-associations/", "en", "breadcrumb").list;
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/en/all-associations/",
+                "en", "breadcrumb", "page", "", "",
+                "", "").list;
             assert(items.filter(f => f.url == 'https://www.epfl.ch/campus/associations/list/en/all-associations/').length == 1);
         });
     });
     describe("Siblings", function() {
         it('a site has siblings', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/website/support-courses-web-workshop/", "en", "siblings").list;
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/support-courses-web-workshop/",
+                "en", "siblings", "page", "", "",
+                "", "").list;
             assert(items.length>1);
         });
         it('a site has a specific sibling', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/website/support-courses-web-workshop/", "en", "siblings").list;
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/support-courses-web-workshop/",
+                "en", "siblings", "page", "", "",
+                "", "").list;
             expect(items.find(f => f.title=='Close a website')).not.be.undefined;
         });
         it("doesn't contain external menus", async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/en/campusenglish/", "en", "siblings").list;
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/campusenglish/",
+                "en", "siblings", "page", "", "",
+                "", "").list;
             assert.deepEqual(items.filter(f => f.object=='epfl-external-menu'), []);
         });
         it('has Room Reservations as sibling', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/", "en", "siblings").list;
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/",
+                "en", "siblings", "page", "", "",
+                "", "").list;
             expect(items.find(f => f.url=='https://www.epfl.ch/campus/services/en/it-services/room-reservations/')).not.be.undefined;
         });
         it('has Storage as sibling', async function() {
-            const items = getMenuItems("https://www.epfl.ch/schools/sb/research/isic/platforms/it-and-data-management-platform/purchasing-procedure/", "en", "siblings").list;
+            const items = getMenuItems("https://www.epfl.ch/schools/sb/research/isic/platforms/it-and-data-management-platform/purchasing-procedure/",
+                "en", "siblings", "page", "", "",
+                "", "").list;
             expect(items.find(f => f.url=='https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/')).not.be.undefined;
         });
         it('has 7 siblings in the level 0', async function() {
-            const items = getMenuItems("https://www.epfl.ch/campus/en/campusenglish/", "en", "siblings").list;
+            const items = getMenuItems("https://www.epfl.ch/campus/en/campusenglish/",
+                "en", "siblings", "page", "", "",
+                "", "").list;
             assert(items.length == 7);
         });
     });

--- a/test/unit/siteTreeTest.ts
+++ b/test/unit/siteTreeTest.ts
@@ -110,20 +110,6 @@ describe("Site Tree", function() {
                 { urlInstanceRestUrl: "https://tototata.com/wp-json/bla?bla", entries: [parent2, child2, child3] }]);
             assert(siteTree.findExternalMenuByRestUrl(child3.rest_url!)?.title=="Some_Page parent 1");
         })
-        it("gets the correct instance parent in a different instance", function() {
-            const jsonService =  fs.readFileSync('./test/unit/data/services.json', 'utf-8');
-            const jsonWebSite =  fs.readFileSync('./test/unit/data/website.json', 'utf-8');
-            const serviceMenu: MenuAPIResult = JSON.parse(jsonService);
-            const websiteMenu: MenuAPIResult = JSON.parse(jsonWebSite);
-            const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "/campus/services/wp-json/epfl/v1/menus/top?lang=en", entries: serviceMenu.items },
-                { urlInstanceRestUrl: "/campus/services/website/wp-json/epfl/v1/menus/top?lang=en", entries: websiteMenu.items }]);
-            const tree1 = siteTree.getParent("/campus/services/website/wp-json/epfl/v1/menus/top?lang=en", 15624);
-            if (tree1) {
-                assert(tree1["/campus/services/wp-json/epfl/v1/menus/top?lang=en"].ID === 7119);
-            } else {
-                assert.fail();
-            }
-        })
         it("gets the correct instance child", function() {
             const jsonServices =  fs.readFileSync('./test/unit/data/services.json', 'utf-8');
             const jsonWebSite =  fs.readFileSync('./test/unit/data/website.json', 'utf-8');


### PR DESCRIPTION
The rest_url attribute in the result of `wp-json/epfl/v1/menus/top?lang=en` call, doesn't contain the domain name of the site.
The menu-api use this field to find the external menus by comparing with the given url.
In a last commit we added the domain name to correct all the home pages that were overwritten in the same item on the map.
The comparison was wrong as the url had the domain name but the rest_url not.
So I parsed now the given url to get the path and the search part.