### PR TITLE
[refactor] typings in the tree API

### DIFF
--- a/menu-api-config.yaml
+++ b/menu-api-config.yaml
@@ -3,12 +3,12 @@ WP_SERVICE_PORT: 8000
 SERVICE_PORT: "3001"
 NODE_TLS_REJECT_UNAUTHORIZED: "0"
 PATH_SITES_FILE: ""
-NAMESPACE: "svc0041t-wordpress"
+NAMESPACE: "svc0041p-wordpress"
 DEBUG: true
 REQUEST_TIMEOUT: 30000
 LABS_LINK_URL_FR: "https://wp-httpd/labs/fr/laboratoires/"
 LABS_LINK_URL_EN: "https://wp-httpd/labs/en/laboratories/"
-ROOT_LINK_URL: "https://wpn-test.epfl.ch/"
+ROOT_LINK_URL: "https://www.epfl.ch/"
 ASSOC_BREADCRUMB_EN: |
   https://wp-httpd/campus/en/campusenglish/
   https://wp-httpd/campus/associations/en/student-associations/
@@ -18,26 +18,26 @@ ASSOC_BREADCRUMB_FR: |
   https://wp-httpd/campus/associations/fr/associations-detudiants/
   https://wp-httpd/campus/associations/list/fr/toutes-les-associations/
 MENU_BAR_LINKS_EN: |
-  https://wpn-test.epfl.ch/about/en/
-  https://wpn-test.epfl.ch/education/en/
-  https://wpn-test.epfl.ch/research/en/
-  https://wpn-test.epfl.ch/innovation/en/
-  https://wpn-test.epfl.ch/schools/en/
-  https://wpn-test.epfl.ch/campus/en/
-  https://wpn-test.epfl.ch/labs/en/
+  https://www.epfl.ch/about/en/
+  https://www.epfl.ch/education/en/
+  https://www.epfl.ch/research/en/
+  https://www.epfl.ch/innovation/en/
+  https://www.epfl.ch/schools/en/
+  https://www.epfl.ch/campus/en/
+  https://www.epfl.ch/labs/en/
 MENU_BAR_LINKS_FR: |
-  https://wpn-test.epfl.ch/about/fr/
-  https://wpn-test.epfl.ch/education/fr/
-  https://wpn-test.epfl.ch/research/fr/
-  https://wpn-test.epfl.ch/innovation/fr/
-  https://wpn-test.epfl.ch/schools/fr/
-  https://wpn-test.epfl.ch/campus/fr/
-  https://wpn-test.epfl.ch/labs/fr/
+  https://www.epfl.ch/about/fr/
+  https://www.epfl.ch/education/fr/
+  https://www.epfl.ch/research/fr/
+  https://www.epfl.ch/innovation/fr/
+  https://www.epfl.ch/schools/fr/
+  https://www.epfl.ch/campus/fr/
+  https://www.epfl.ch/labs/fr/
 MENU_BAR_LINKS_DE: |
-  https://wpn-test.epfl.ch/about/de/
-  https://wpn-test.epfl.ch/education/de/
-  https://wpn-test.epfl.ch/research/de/
-  https://wpn-test.epfl.ch/innovation/de/
-  https://wpn-test.epfl.ch/schools/de/
-  https://wpn-test.epfl.ch/campus/de/
-  https://wpn-test.epfl.ch/labs/en/
+  https://www.epfl.ch/about/de/
+  https://www.epfl.ch/education/de/
+  https://www.epfl.ch/research/de/
+  https://www.epfl.ch/innovation/de/
+  https://www.epfl.ch/schools/de/
+  https://www.epfl.ch/campus/de/
+  https://www.epfl.ch/labs/en/

--- a/src/interfaces/siteTree.ts
+++ b/src/interfaces/siteTree.ts
@@ -3,23 +3,23 @@ import {external_detached_menus_counter, info, warn} from "../utils/logger";
 import {MenuEntry} from "./MenuEntry";
 import {getSiteTreeReadOnlyByLanguage} from "../menus/refresh";
 
-type MenuEntryByUrl = {[urlInstanceRestUrl : string]: MenuEntry};
+export type MenuEntryAndUrl = {urlInstanceRestUrl : string, entry: MenuEntry};
 
 export interface SiteTreeInstance  {
-    getParent : (urlInstanceRestUrl: string,  idChild: number) => MenuEntryByUrl | undefined
+    getParent : (urlInstanceRestUrl: string,  idChild: number) => MenuEntryAndUrl | undefined
     getChildren : (urlInstanceRestUrl: string, idParent: number) => MenuEntry[]
     findExternalMenuByRestUrl : (urlInstanceRestUrl: string) => MenuEntry | undefined
     findItemByRestUrlAndId: (urlInstanceRestUrl: string, idItem: number) => MenuEntry | undefined
     getSiblings : (urlInstanceRestUrl: string, idItem: number) => MenuEntry[]
-    findItemByUrl: (pageURL: string) => MenuEntryByUrl | undefined
-    findItemAndObjectTypeByUrl: (pageURL: string) => { result: MenuEntryByUrl | undefined, objectType: string}
-    findLevelZeroByUrl: (pageURL: string) => MenuEntryByUrl | undefined
+    findItemByUrl: (pageURL: string) => MenuEntryAndUrl | undefined
+    findItemAndObjectTypeByUrl: (pageURL: string) => { result: MenuEntryAndUrl | undefined, objectType: string}
+    findLevelZeroByUrl: (pageURL: string) => MenuEntryAndUrl | undefined
     length: () => number
-    getCustomMenus: () => { urlInstanceRestUrl: string, entries: MenuEntry }[]
-    getExternalMenus: () => { urlInstanceRestUrl: string, entries: MenuEntry }[]
-    getPages: () => { urlInstanceRestUrl: string, entries: MenuEntry }[]
-    getPosts: () => { urlInstanceRestUrl: string, entries: MenuEntry }[]
-    getCategories: () => { urlInstanceRestUrl: string, entries: MenuEntry }[]
+    getCustomMenus: () => MenuEntryAndUrl[]
+    getExternalMenus: () => MenuEntryAndUrl[]
+    getPages: () => MenuEntryAndUrl[]
+    getPosts: () => MenuEntryAndUrl[]
+    getCategories: () => MenuEntryAndUrl[]
 }
 
 export type SiteTreeConstructor = (menus : { urlInstanceRestUrl: string, entries: MenuEntry[] | undefined }[]) => SiteTreeInstance
@@ -29,10 +29,10 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
     const parents: { [urlInstanceRestUrl : string]: { [idChild : number]: MenuEntry } } = {};
     const children: { [urlInstanceRestUrl : string]: { [idParent : number]: MenuEntry[] } } = {};
     const externalMenus: { [urlInstanceRestUrl : string]: MenuEntry[] } = {};
-    const notCustomItemsByUrl : { [fullUrl : string]: MenuEntryByUrl } = {};
-    const customItemsByUrl : { [fullUrl : string]: MenuEntryByUrl } = {};
-    const levelZeroByUrl : { [urlSiteWithoutHomePage : string]: MenuEntryByUrl } = {};
-    const menusEntriesByObjectType: {[objectType: string] : { urlInstanceRestUrl: string, entries: MenuEntry }[]} = {}
+    const notCustomItemsByUrl : { [fullUrl : string]: MenuEntryAndUrl } = {};
+    const customItemsByUrl : { [fullUrl : string]: MenuEntryAndUrl } = {};
+    const levelZeroByUrl : { [urlSiteWithoutHomePage : string]: MenuEntryAndUrl } = {};
+    const menuEntriesByObjectType: {[objectType: string] : MenuEntryAndUrl[]} = {}
 
     info(`START ANALYSE`, { method: 'SiteTreeReadOnly' });
 
@@ -69,51 +69,52 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
             /*** get all notCustomItems and customItems by url ***/
             const fullUrl = item.getFullUrl();
             if(fullUrl && item.object !== 'custom') {
-                if (!notCustomItemsByUrl[fullUrl]) {
-                    notCustomItemsByUrl[fullUrl] = {};
+                notCustomItemsByUrl[fullUrl] = {
+                    urlInstanceRestUrl: menu.urlInstanceRestUrl,
+                    entry: item
                 }
-                notCustomItemsByUrl[fullUrl][menu.urlInstanceRestUrl] = item;
             } else if(fullUrl && item.object == 'custom') {
-                if (!customItemsByUrl[fullUrl]) {
-                    customItemsByUrl[fullUrl] = {};
+                customItemsByUrl[fullUrl] = {
+                    urlInstanceRestUrl: menu.urlInstanceRestUrl,
+                    entry: item
                 }
-                customItemsByUrl[fullUrl][menu.urlInstanceRestUrl] = item;
             }
 
             /*** get all levelZero by url ***/
             if(item.menu_item_parent.toString() === "0" && item.menu_order === 1 && item.getFullUrl()) {
                 const urlSiteWithoutHomePage = getBaseUrl(item.getFullUrl());
-                if (!levelZeroByUrl[urlSiteWithoutHomePage]) {
-                    levelZeroByUrl[urlSiteWithoutHomePage] = {};
-                }
-                levelZeroByUrl[urlSiteWithoutHomePage][menu.urlInstanceRestUrl] = item;
+                levelZeroByUrl[urlSiteWithoutHomePage] = {
+                  urlInstanceRestUrl: menu.urlInstanceRestUrl,
+                  entry: item
+                };
             }
 
             /*** group all menusEntries by object type ***/
-            if (!menusEntriesByObjectType[item.object]) {
-                menusEntriesByObjectType[item.object] = [];
+            if (!menuEntriesByObjectType[item.object]) {
+                menuEntriesByObjectType[item.object] = [];
             }
-            menusEntriesByObjectType[item.object].push({urlInstanceRestUrl: menu.urlInstanceRestUrl, entries: item});
+            menuEntriesByObjectType[item.object].push({urlInstanceRestUrl: menu.urlInstanceRestUrl, entry: item});
         });
     });
 
     info(`END ANALYSE`, { method: 'SiteTreeReadOnly' });
 
     return {
-        getParent(urlInstanceRestUrl: string, idChild:number): MenuEntryByUrl {
-            const result: MenuEntryByUrl = {};
-            const parent = parents[urlInstanceRestUrl][idChild];//it could be undefined;
-            if (parent === undefined) {
-                for (const [url, menuEntries] of Object.entries(externalMenus)) {
-                    const entry = menuEntries.find(menuEntry => menuEntry.getFullUrl() === urlInstanceRestUrl);
-                    if (entry) {
-                        result[url] = itemsByID[url][entry.menu_item_parent];
-                        return result;
-                    }
+        getParent(urlInstanceRestUrl: string, idChild:number): MenuEntryAndUrl | undefined {
+            const parent = parents[urlInstanceRestUrl][idChild];
+            if (parent) {
+                return { urlInstanceRestUrl, entry: parent };
+            }
+
+            for (const [url, menuEntries] of Object.entries(externalMenus)) {
+                const entry = menuEntries.find(menuEntry => menuEntry.getFullUrl() === urlInstanceRestUrl);
+                if (entry) {
+                    return {
+                        urlInstanceRestUrl: url,
+                        entry: itemsByID[url][entry.menu_item_parent]
+                    };
                 }
             }
-            result[urlInstanceRestUrl] = parent;
-            return result;
         },
         getChildren(urlInstanceRestUrl: string, idParent:number) {
             const childrenInTheSameSite = children[urlInstanceRestUrl][idParent] || [];
@@ -142,13 +143,7 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
         getSiblings(urlInstanceRestUrl: string, idItem:number)  {
             const parent = this.getParent(urlInstanceRestUrl,idItem);
             if (parent) {
-                const newUrl = Object.keys(parent)[0];
-                if (parent[newUrl]) {
-                    const children = this.getChildren(newUrl,parent[newUrl].ID);
-                    return children;
-                }else {
-                    return [];
-                }
+                return this.getChildren(parent.urlInstanceRestUrl, parent.entry.ID);
             } else {
                 return []
             }
@@ -168,18 +163,18 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
         findItemByRestUrlAndId(urlInstanceRestUrl: string, idItem: number) {
             return itemsByID[urlInstanceRestUrl][idItem];
         },
-        findItemByUrl(pageURL: string): MenuEntryByUrl | undefined {
+        findItemByUrl(pageURL: string): MenuEntryAndUrl | undefined {
             return notCustomItemsByUrl[pageURL];
         },
         findItemAndObjectTypeByUrl(pageURL: string) {
-            let result: MenuEntryByUrl | undefined;
+            let result: MenuEntryAndUrl | undefined;
             let objectType: string = '';
-            const notCustomItem: MenuEntryByUrl | undefined = notCustomItemsByUrl[pageURL];
+            const notCustomItem = notCustomItemsByUrl[pageURL];
             if (notCustomItem) {
                 result = notCustomItem;
-                objectType = notCustomItem[Object.keys(notCustomItem)[0]].object;
+                objectType = notCustomItem.entry.object;
             } else {
-                const customItem: MenuEntryByUrl | undefined = customItemsByUrl[pageURL];
+                const customItem = customItemsByUrl[pageURL];
                 if (customItem) {
                     objectType = 'custom';
                 }
@@ -193,19 +188,19 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
             return menus.length;
         },
         getCustomMenus () {
-            return menusEntriesByObjectType['custom'] ?? [];
+            return menuEntriesByObjectType['custom'] ?? [];
         },
         getExternalMenus () {
-            return menusEntriesByObjectType['epfl-external-menu'] ?? [];
+            return menuEntriesByObjectType['epfl-external-menu'] ?? [];
         },
         getPages () {
-            return menusEntriesByObjectType['page'] ?? [];
+            return menuEntriesByObjectType['page'] ?? [];
         },
         getPosts () {
-            return menusEntriesByObjectType['post'] ?? [];
+            return menuEntriesByObjectType['post'] ?? [];
         },
         getCategories () {
-            return menusEntriesByObjectType['category'] ?? [];
+            return menuEntriesByObjectType['category'] ?? [];
         },
     }
 }

--- a/src/interfaces/siteTree.ts
+++ b/src/interfaces/siteTree.ts
@@ -145,7 +145,7 @@ export const SiteTreeReadOnly : SiteTreeConstructor = function(menus) {
                 const newUrl = Object.keys(parent)[0];
                 if (parent[newUrl]) {
                     const children = this.getChildren(newUrl,parent[newUrl].ID);
-                    return children;//.filter(menu => menu.ID!=idItem);
+                    return children;
                 }else {
                     return [];
                 }

--- a/src/menus/lists.ts
+++ b/src/menus/lists.ts
@@ -10,14 +10,14 @@ import {getSiteTreeReadOnlyByLanguage} from "./refresh";
 import { flatSitemap } from "src/utils/flatSitemap";
 
 function searchAllParentsEntriesByID(entry: MenuEntry, urlInstanceRestUrl: string, siteArray: SiteTreeInstance, labLink: string, assocBreadcrumbs: string[]): MenuEntry[] {
-    const parent: { [urlInstance : string]: MenuEntry } | undefined = siteArray.getParent(urlInstanceRestUrl,entry.ID);
+    const parent = siteArray.getParent(urlInstanceRestUrl,entry.ID);
 
     if (parent) {
-        const newUrl = Object.keys(parent)[0];
+        const newUrl = parent.urlInstanceRestUrl;
 
-        if (parent[newUrl]) {
-            const parents: MenuEntry[] = searchAllParentsEntriesByID(parent[newUrl], newUrl , siteArray, labLink, assocBreadcrumbs);
-            return [...parents, parent[newUrl]];
+        if (newUrl) {
+            const parents: MenuEntry[] = searchAllParentsEntriesByID(parent.entry, newUrl , siteArray, labLink, assocBreadcrumbs);
+            return [...parents, parent.entry];
         } else {
             return searchParentForLabAndAssoc(urlInstanceRestUrl, siteArray, entry, labLink, assocBreadcrumbs);
         }
@@ -39,9 +39,8 @@ function searchParentForLabAndAssoc(url: string, siteArray: SiteTreeInstance, en
         assocBreadcrumbs.forEach(u => {
             const menu = siteArray!.findItemByUrl(u);
             if (menu) {
-                const k = Object.keys(menu)[0];
-                if (menu[k] && menu[k].getFullUrl()!==entry.getFullUrl()) {
-                    items.push(menu[k]);
+                if (menu.entry.getFullUrl() !== entry.getFullUrl()) {
+                    items.push(menu.entry);
                 }
             }
         });
@@ -51,12 +50,9 @@ function searchParentForLabAndAssoc(url: string, siteArray: SiteTreeInstance, en
 }
 
 function getItemMenuByUrl(siteArray: SiteTreeInstance, url: string) {
-    const item: { [urlInstance : string]: MenuEntry } | undefined = siteArray.findItemByUrl(url);
+    const item = siteArray.findItemByUrl(url);
     if (item) {
-        const itemUrl = Object.keys(item)[0];
-        if (item[itemUrl]) {
-            return item[itemUrl];
-        }
+        return item.entry;
     }
     return undefined;
 }
@@ -71,12 +67,11 @@ export function getMenuItems (url: string, lang: string, method: "siblings"|"bre
         let siteArray: SiteTreeInstance | undefined = m.menus[lang];
 
         if (siteArray) {
-            const firstSite: { result: { [urlInstance: string]: MenuEntry } | undefined, objectType: string } = siteArray.findItemAndObjectTypeByUrl(url);
+            const firstSite = siteArray.findItemAndObjectTypeByUrl(url);
 
             if (firstSite.result) {
-                const restUrl = Object.keys(firstSite.result)[0];
-                info('Page found', {url: restUrl, lang: lang, method: 'getMenuItems: '.concat(method)});
-                items = getMenuEntryFromFirstSite(firstSite.result, restUrl, siteArray, lang)[method]();
+                info('Page found', {url: firstSite.result.urlInstanceRestUrl, lang: lang, method: 'getMenuItems: '.concat(method)});
+                items = getMenuEntryFromFirstSite(firstSite.result.entry, firstSite.result.urlInstanceRestUrl, siteArray, lang)[method]();
                 orphan_pages_counter.labels( {url: url, lang: lang }).set(0);
             } else {
                 if (firstSite.objectType != 'custom' && firstSite.objectType != 'post') {
@@ -91,10 +86,10 @@ export function getMenuItems (url: string, lang: string, method: "siblings"|"bre
                     const levelzero = siteArray.findLevelZeroByUrl(homePageUrl);
 
                     if (levelzero) {
-                        const restUrl = Object.keys(levelzero)[0];
+                        const restUrl = levelzero.urlInstanceRestUrl;
                         info('Site home page for post found', {url: restUrl, lang: lang, method: 'getMenuItems: '.concat(method)});
 
-                        items = getMenuEntryFromFirstSite(levelzero, restUrl, siteArray, lang)[method]();
+                        items = getMenuEntryFromFirstSite(levelzero.entry, restUrl, siteArray, lang)[method]();
 
                         // The post home page is added to the site home page breadcrumb
                         // The post home page name and url are retrieved from WordPress, if defined,
@@ -138,36 +133,31 @@ export function getMenuItems (url: string, lang: string, method: "siblings"|"bre
 }
 
 function getSiblingsForBreadcrumb(siteArray: SiteTreeInstance, url: string, lang: string) {
-    const firstSite: { result: { [urlInstance: string]: MenuEntry } | undefined, objectType: string } = siteArray.findItemAndObjectTypeByUrl(url);
+    const firstSite = siteArray.findItemAndObjectTypeByUrl(url);
     if (firstSite.result) {
-        const restUrl = Object.keys(firstSite.result)[0];
-        return getMenuEntryFromFirstSite(firstSite.result, restUrl, siteArray, lang).siblings();
+        return getMenuEntryFromFirstSite(firstSite.result.entry,
+            firstSite.result.urlInstanceRestUrl, siteArray, lang).siblings();
     } else {
         return [];
     }
 }
 
-function getMenuEntryFromFirstSite(firstSite: {
-    [p: string]: MenuEntry
-}, restUrl: string, siteArray: SiteTreeInstance, lang: string) :
+function getMenuEntryFromFirstSite(firstSite: MenuEntry, restUrl: string, siteArray: SiteTreeInstance, lang: string) :
     {breadcrumb: () => MenuEntry[], siblings: () => MenuEntry[], children: () => MenuEntry[], currentPage: () => MenuEntry[]} {
-    if (firstSite[restUrl]) {
+    if (firstSite) {
         return {
             siblings() {
-                const items = siteArray.getSiblings(restUrl,firstSite[restUrl].ID);
+                const items = siteArray.getSiblings(restUrl,firstSite.ID);
 
                 //We create manually siblings list for level zero of menus (about, education, research, innovation, schools, campus, labs)
-                if (items.length == 0 && firstSite[restUrl].menu_item_parent.toString() == "0" && firstSite[restUrl].menu_order === 1 && firstSite[restUrl].getFullUrl()) {
+                if (items.length == 0 && firstSite.menu_item_parent.toString() == "0" && firstSite.menu_order === 1 && firstSite.getFullUrl()) {
                     const listMenuBarLinks: string[] = getMenuBarLinks(lang);
-                    const urlSiteWithoutHomePage: string = getBaseUrl(firstSite[restUrl].getFullUrl()!);
+                    const urlSiteWithoutHomePage: string = getBaseUrl(firstSite.getFullUrl()!);
                     if (Array.isArray(listMenuBarLinks) && listMenuBarLinks.includes(urlSiteWithoutHomePage)) {
                         listMenuBarLinks.forEach(u => {
                             const menu = siteArray!.findLevelZeroByUrl(u);
                             if (menu) {
-                                const k = Object.keys(menu)[0];
-                                if (menu[k]) {
-                                    items.push(menu[k]);
-                                }
+                                items.push(menu.entry);
                             }
                         });
                     }
@@ -177,20 +167,20 @@ function getMenuEntryFromFirstSite(firstSite: {
                 // (`@Primary` menus, if any)
                 // Reminder: all the `@Primary` menus not correctly attached to the menu are deleted from the result in the items list
                 if (items.length == 0) {
-                    items.push(firstSite[restUrl]);
+                    items.push(firstSite);
                 }
                 return items;
             },
             breadcrumb() {
                 const labLink = getLabsLink(lang);
                 const assocBreadcrumbs = getAssocBreadcrumb(lang);
-                return [...searchAllParentsEntriesByID(firstSite[restUrl], restUrl, siteArray, labLink, assocBreadcrumbs), firstSite[restUrl]];
+                return [...searchAllParentsEntriesByID(firstSite, restUrl, siteArray, labLink, assocBreadcrumbs), firstSite];
             },
             children() {
-                return siteArray.getChildren(restUrl,firstSite[restUrl].ID);
+                return siteArray.getChildren(restUrl,firstSite.ID);
             },
             currentPage() {
-                return [firstSite[restUrl]];
+                return [firstSite];
             }
         };
     } else {
@@ -235,7 +225,7 @@ export function getSitesHierarchy(url: string, lang: string, config: Config | un
             sitemap = listMenuBarLinks.map(menuBarLink => {
                 const levelZero = siteArray!.findLevelZeroByUrl(menuBarLink);
                 if (levelZero) {
-                    const menuBarFullUrl = levelZero[Object.keys(levelZero)[0]].getFullUrl()
+                    const menuBarFullUrl = levelZero.entry.getFullUrl()
                     return findChildrenFromUrl(menuBarFullUrl, lang, siteArray!);
                 }
             })
@@ -248,11 +238,11 @@ export function getSitesHierarchy(url: string, lang: string, config: Config | un
 
 function findChildrenFromUrl(url: string, lang: string, siteArray: SiteTreeInstance, visited = new Set()) {
     visited.add(url);
-    const firstSite: { result: { [urlInstance: string]: MenuEntry } | undefined, objectType: string } = siteArray.findItemAndObjectTypeByUrl(url);
+    const firstSite = siteArray.findItemAndObjectTypeByUrl(url);
 
     if (firstSite.result) {
         const restUrl = Object.keys(firstSite.result)[0];
-        const children = getMenuEntryFromFirstSite(firstSite.result, restUrl, siteArray, lang)["children"]()
+        const children = getMenuEntryFromFirstSite(firstSite.result.entry, restUrl, siteArray, lang)["children"]()
           .filter(c => !visited.has(c.getFullUrl()));
         const allChildren: any[] = children
           .map(child => findChildrenFromUrl(child.getFullUrl(), lang, siteArray, visited))

--- a/src/menus/lists.ts
+++ b/src/menus/lists.ts
@@ -61,18 +61,6 @@ function getItemMenuByUrl(siteArray: SiteTreeInstance, url: string) {
     return undefined;
 }
 
-function getLabOrAssoc(url: string, siteArray: SiteTreeInstance): MenuEntry | undefined {
-    const labsOrAssoc: { [urlInstance : string]: MenuEntry } | undefined = siteArray.findItemByUrl(url);
-    if (labsOrAssoc) {
-        const labUrl = Object.keys(labsOrAssoc)[0];
-        if (labsOrAssoc[labUrl]) {
-            return labsOrAssoc[labUrl];
-        }
-    }
-    info('Get lab or assoc: undefined', {url: url, method: 'getLabOrAssoc'});
-    return undefined
-}
-
 export function getMenuItems (url: string, lang: string, method: "siblings"|"breadcrumb"|"children"|"currentPage", pageType: string, mainPostPageName: string,
                               mainPostPageUrl: string, homePageUrl: string, currentPostName: string) : {list: {title: string, url: string, object: string}[], errors: number} {
     let err = 0;

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -1,6 +1,7 @@
 import {total_categories, total_pages, total_posts, total_retrieved_sites,} from "./logger";
 import {MenuEntry} from "../interfaces/MenuEntry";
 import {SiteTreeReadOnlyByLanguage} from "./siteTreeByLanguage";
+import {MenuEntryAndUrl} from '../interfaces/siteTree';
 
 export function getRetrievedSitesCount(menus: SiteTreeReadOnlyByLanguage) {
 	for (const lang in menus.menus) {
@@ -49,13 +50,13 @@ export function getCategoriesCount(menus: SiteTreeReadOnlyByLanguage) {
 	}
 }
 
-function getGroupedArray(pages: {urlInstanceRestUrl: string, entries: MenuEntry}[]) {
-	return pages.reduce((grouped: { [site: string]: MenuEntry[] }, page: { urlInstanceRestUrl: string, entries: MenuEntry }) => {
+function getGroupedArray(pages: MenuEntryAndUrl[]) {
+	return pages.reduce((grouped: { [site: string]: MenuEntry[] }, page: MenuEntryAndUrl) => {
 		const site = cleanUrl(page.urlInstanceRestUrl);
 		if (!grouped[site]) {
 			grouped[site] = [];
 		}
-		grouped[site].push(page.entries);
+		grouped[site].push(page.entry);
 		return grouped;
 	}, {});
 }

--- a/test/e2e/lists.ts
+++ b/test/e2e/lists.ts
@@ -31,7 +31,7 @@ describe("End To End Menu", function() {
                 "en", "breadcrumb", "page", "Systems updates feed",
                 "https://wpn-test.epfl.ch/campus/services/website/blog-page/",
                 "https://wpn-test.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
-            assert(items.length>1);
+            assert.isAbove(items.length, 1);
         });
         it('website has Services & Resources as parent', async function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/en/website/",
@@ -58,13 +58,13 @@ describe("End To End Menu", function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/labs/en/laboratories/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert(items.length == 1);
+            assert.equal(items.length, 1);
         });
         it('Alice has Labs as parent', async function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/labs/alice/en/index-fr-html/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert(items.length == 2);
+            assert.equal(items.length, 2);
             expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/labs/en/laboratories/')).not.be.undefined;
         });
         it('all-associations has Student Assoc and campus as parents', async function() {
@@ -78,21 +78,21 @@ describe("End To End Menu", function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/spaceat/en/spaceyourservice/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert(items.length == 4);
+            assert.equal(items.length, 4);
             expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/')).not.be.undefined;
         });
         it('adec assoc has campus in parents', async function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/adec/index-html/the-comitee/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert(items.length == 5);
+            assert.equal(items.length, 5);
             expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
         });
         it('has one list assoc item', async function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert(items.filter(f => f.url == 'https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/').length == 1);
+            assert.equal(items.filter(f => f.url == 'https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/').length, 1);
         });
     });
     describe("Siblings", function() {
@@ -100,7 +100,7 @@ describe("End To End Menu", function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/support-courses-web-workshop/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
-            assert(items.length>1);
+            assert.isAbove(items.length, 1);
         });
         it('a site has a specific sibling', async function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/support-courses-web-workshop/",
@@ -136,20 +136,20 @@ describe("End To End Menu", function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/en/campusenglish/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
-            assert(items.length == 7);
+            assert.equal(items.length, 7);
         });
         it('italian language has breadcrumb in english', async function() {
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/it/test-italiano/",
                 "it", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert(items.length > 1);
+            assert.isAbove(items.length, 1);
         });
         it('crc is the child of IT Services & Resources', async function () {
             const config = loadConfig('menu-api-config.yaml');
             const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/it-services/",
                 "en", "siblings", "page", "", "",
                 "https://wpn-test.epfl.ch/campus/services/en/", "IT Services & Resources").list;
-            assert(items.length > 1);
+            assert.isAbove(items.length, 1);
         });
     });
     describe("ChildrenSite", function() {
@@ -157,41 +157,41 @@ describe("End To End Menu", function() {
             const config = loadConfig('menu-api-config.yaml');
             const items = await getSiteTree("https://wpn-test.epfl.ch/campus/",
                 config);
-            assert(items.children.length > 1);
+            assert.isAbove(items.children.length, 1);
         });
         it('campus has some children without /', async function () {
             const config = loadConfig('menu-api-config.yaml');
             const items = await getSiteTree("https://wpn-test.epfl.ch/campus",
                 config);
-            assert(items.children.length > 1);
+            assert.isAbove(items.children.length, 1);
         });
         it('campus has association as child', async function () {
             const config = loadConfig('menu-api-config.yaml');
             const items = await getSiteTree("https://wpn-test.epfl.ch/campus/",
                 config);
             const filteredList = items.children.filter(site => site.path == "/campus/associations");
-            assert(filteredList.length == 1);
+            assert.equal(filteredList.length, 1);
         });
         it('campus doesn\'t have association/list as child', async function () {
             const config = loadConfig('menu-api-config.yaml');
             const items = await getSiteTree("https://wpn-test.epfl.ch/campus/",
                 config);
             const filteredList = items.children.filter(site => site.path == "/campus/associations/list");
-            assert(filteredList.length == 0);
+            assert.equal(filteredList.length, 0);
         });
         it('campus doesn\'t have association/list as child', async function () {
             const config = loadConfig('menu-api-config.yaml');
             const items = await getSiteTree("https://wpn-test.epfl.ch/campus/associations",
                 config);
             const filteredList = items.children.filter(site => site.path == "/campus/associations/list");
-            assert(filteredList.length == 1);
+            assert.equal(filteredList.length, 1);
         });
         it('campus is the parent of association', async function () {
             const config = loadConfig('menu-api-config.yaml');
             const items = await getSiteTree("https://wpn-test.epfl.ch/campus/associations",
                 config);
             const filteredList = items.parent.filter(site => site.path == "/campus");
-            assert(filteredList.length == 1);
+            assert.equal(filteredList.length, 1);
         });
     });
 });

--- a/test/e2e/lists.ts
+++ b/test/e2e/lists.ts
@@ -9,7 +9,7 @@ import {configSite} from "../../src/interfaces/site";
 
 describe("End To End Menu", function() {
     before(function(done){
-        this.timeout(50000);
+        this.timeout(100000);
 
         const config = loadConfig('menu-api-config.yaml');
         if (config) {
@@ -27,168 +27,168 @@ describe("End To End Menu", function() {
     });
     describe("Breadcrumb", function() {
         it('website has at least one parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/en/website/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/",
                 "en", "breadcrumb", "page", "Systems updates feed",
-                "https://wpn-test.epfl.ch/campus/services/website/blog-page/",
-                "https://wpn-test.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
+                "https://www.epfl.ch/campus/services/website/blog-page/",
+                "https://www.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
             assert.isAbove(items.length, 1);
         });
         it('website has Services & Resources as parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/en/website/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/",
                 "en", "breadcrumb", "page", "Systems updates feed",
-                "https://wpn-test.epfl.ch/campus/services/website/blog-page/",
-                "https://wpn-test.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
+                "https://www.epfl.ch/campus/services/website/blog-page/",
+                "https://www.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
             expect(items.find(f => f.title=='Services &amp; Resources')).not.be.undefined;
         });
         it('storage-of-documents has a specific parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/it-services/storage-of-documents/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/",
                 "en", "breadcrumb", "page", "",
                 "",
-                "https://wpn-test.epfl.ch/campus/services/en", "Data Storage Solutions").list;
+                "https://www.epfl.ch/campus/services/en", "Data Storage Solutions").list;
             expect(items.find(f => f.title=='Services &amp; Resources')).not.be.undefined;
         });
         it('website has Campus as parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/en/website/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/en/website/",
                 "en", "breadcrumb", "page", "Systems updates feed",
-                "https://wpn-test.epfl.ch/campus/services/website/blog-page/",
-                "https://wpn-test.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
+                "https://www.epfl.ch/campus/services/website/blog-page/",
+                "https://www.epfl.ch/campus/services/website/en/", "EPFL Websites").list;
             expect(items.find(f => f.title=='Campus')).not.be.undefined;
         });
         it('laboratories has no Lab parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/labs/en/laboratories/",
+            const items = getMenuItems("https://www.epfl.ch/labs/en/laboratories/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
             assert.equal(items.length, 1);
         });
         it('Alice has Labs as parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/labs/alice/en/index-fr-html/",
+            const items = getMenuItems("https://www.epfl.ch/labs/alice/en/index-fr-html/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
             assert.equal(items.length, 2);
-            expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/labs/en/laboratories/')).not.be.undefined;
+            expect(items.find(f => f.url == 'https://www.epfl.ch/labs/en/laboratories/')).not.be.undefined;
         });
         it('all-associations has Student Assoc and campus as parents', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/",
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/en/all-associations/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/campus/associations/en/student-associations/')).not.be.undefined;
-            expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
+            expect(items.find(f => f.url == 'https://www.epfl.ch/campus/associations/en/student-associations/')).not.be.undefined;
+            expect(items.find(f => f.url == 'https://www.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
         });
         it('spaceyourservice has Assoc as parent', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/spaceat/en/spaceyourservice/",
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/spaceat/en/spaceyourservice/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
             assert.equal(items.length, 4);
-            expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/')).not.be.undefined;
+            expect(items.find(f => f.url == 'https://www.epfl.ch/campus/associations/list/en/all-associations/')).not.be.undefined;
         });
         it('adec assoc has campus in parents', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/adec/index-html/the-comitee/",
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/adec/index-html/the-comitee/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
             assert.equal(items.length, 5);
-            expect(items.find(f => f.url == 'https://wpn-test.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
+            expect(items.find(f => f.url == 'https://www.epfl.ch/campus/en/campusenglish/')).not.be.undefined;
         });
         it('has one list assoc item', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/",
+            const items = getMenuItems("https://www.epfl.ch/campus/associations/list/en/all-associations/",
                 "en", "breadcrumb", "page", "", "",
                 "", "").list;
-            assert.equal(items.filter(f => f.url == 'https://wpn-test.epfl.ch/campus/associations/list/en/all-associations/').length, 1);
+            assert.equal(items.filter(f => f.url == 'https://www.epfl.ch/campus/associations/list/en/all-associations/').length, 1);
         });
     });
     describe("Siblings", function() {
         it('a site has siblings', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/support-courses-web-workshop/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/support-courses-web-workshop/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
             assert.isAbove(items.length, 1);
         });
         it('a site has a specific sibling', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/website/support-courses-web-workshop/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/website/support-courses-web-workshop/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
             expect(items.find(f => f.title=='Close a website')).not.be.undefined;
         });
         it("doesn't contain external menus", async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/campusenglish/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/campusenglish/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
             assert.deepEqual(items.filter(f => f.object=='epfl-external-menu'), []);
         });
         it('has Room Reservations as sibling', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/it-services/storage-of-documents/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/storage-of-documents/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
-            expect(items.find(f => f.url=='https://wpn-test.epfl.ch/campus/services/en/it-services/room-reservations/')).not.be.undefined;
+            expect(items.find(f => f.url=='https://www.epfl.ch/campus/services/en/it-services/room-reservations/')).not.be.undefined;
         });
         it('Services has Art&Culture as sibling', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/homepage/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/homepage/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
-            expect(items.find(f => f.url=='https://wpn-test.epfl.ch/campus/art-culture/en/art-culture/')).not.be.undefined;
+            expect(items.find(f => f.url=='https://www.epfl.ch/campus/art-culture/en/art-culture/')).not.be.undefined;
         });
         it('laptop has smartphone as sibling', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/it-services/myprint/procedure/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/myprint/procedure/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
-            expect(items.find(f => f.url=='https://wpn-test.epfl.ch/campus/services/en/it-services/myprint/search-printer/')).not.be.undefined;
+            expect(items.find(f => f.url=='https://www.epfl.ch/campus/services/en/it-services/myprint/search-printer/')).not.be.undefined;
         });
         it('has 7 siblings in the level 0', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/en/campusenglish/",
+            const items = getMenuItems("https://www.epfl.ch/campus/en/campusenglish/",
                 "en", "siblings", "page", "", "",
                 "", "").list;
             assert.equal(items.length, 7);
         });
         it('italian language has breadcrumb in english', async function() {
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/it/test-italiano/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/it/test-italiano/",
                 "it", "breadcrumb", "page", "", "",
                 "", "").list;
             assert.isAbove(items.length, 1);
         });
         it('crc is the child of IT Services & Resources', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = getMenuItems("https://wpn-test.epfl.ch/campus/services/en/it-services/",
+            const items = getMenuItems("https://www.epfl.ch/campus/services/en/it-services/",
                 "en", "siblings", "page", "", "",
-                "https://wpn-test.epfl.ch/campus/services/en/", "IT Services & Resources").list;
+                "https://www.epfl.ch/campus/services/en/", "IT Services & Resources").list;
             assert.isAbove(items.length, 1);
         });
     });
     describe("ChildrenSite", function() {
         it('campus has some children', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = await getSiteTree("https://wpn-test.epfl.ch/campus/",
+            const items = await getSiteTree("https://www.epfl.ch/campus/",
                 config);
             assert.isAbove(items.children.length, 1);
         });
         it('campus has some children without /', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = await getSiteTree("https://wpn-test.epfl.ch/campus",
+            const items = await getSiteTree("https://www.epfl.ch/campus",
                 config);
             assert.isAbove(items.children.length, 1);
         });
         it('campus has association as child', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = await getSiteTree("https://wpn-test.epfl.ch/campus/",
+            const items = await getSiteTree("https://www.epfl.ch/campus/",
                 config);
             const filteredList = items.children.filter(site => site.path == "/campus/associations");
             assert.equal(filteredList.length, 1);
         });
         it('campus doesn\'t have association/list as child', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = await getSiteTree("https://wpn-test.epfl.ch/campus/",
+            const items = await getSiteTree("https://www.epfl.ch/campus/",
                 config);
             const filteredList = items.children.filter(site => site.path == "/campus/associations/list");
             assert.equal(filteredList.length, 0);
         });
         it('campus doesn\'t have association/list as child', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = await getSiteTree("https://wpn-test.epfl.ch/campus/associations",
+            const items = await getSiteTree("https://www.epfl.ch/campus/associations",
                 config);
             const filteredList = items.children.filter(site => site.path == "/campus/associations/list");
             assert.equal(filteredList.length, 1);
         });
         it('campus is the parent of association', async function () {
             const config = loadConfig('menu-api-config.yaml');
-            const items = await getSiteTree("https://wpn-test.epfl.ch/campus/associations",
+            const items = await getSiteTree("https://www.epfl.ch/campus/associations",
                 config);
             const filteredList = items.parent.filter(site => site.path == "/campus");
             assert.equal(filteredList.length, 1);

--- a/test/e2e/sitemap.ts
+++ b/test/e2e/sitemap.ts
@@ -28,7 +28,7 @@ describe("End To End SiteHierarchy", function() {
         }
     });
     it('is not empty', async function() {
-        const siteHierarchy = getSitesHierarchy("https://wpn-test.epfl.ch/campus/services/en/homepage/", "en", config);
+        const siteHierarchy = getSitesHierarchy("https://www.epfl.ch/campus/services/en/homepage/", "en", config);
         assert.isAbove(siteHierarchy.length, 0);
     });
 });

--- a/test/e2e/sitemap.ts
+++ b/test/e2e/sitemap.ts
@@ -29,6 +29,6 @@ describe("End To End SiteHierarchy", function() {
     });
     it('is not empty', async function() {
         const siteHierarchy = getSitesHierarchy("https://wpn-test.epfl.ch/campus/services/en/homepage/", "en", config);
-        assert(siteHierarchy.length > 0);
+        assert.isAbove(siteHierarchy.length, 0);
     });
 });

--- a/test/unit/kubernetesClient.ts
+++ b/test/unit/kubernetesClient.ts
@@ -10,13 +10,13 @@ describe('Kubernetes Client Test', () => {
     it('should find wp-nginx pod', async () => {
         const kc = new KubeConfig();
         kc.loadFromDefault();
-        const podName = await getK8SPodName("svc0041t-wordpress")
+        const podName = await getK8SPodName("svc0041p-wordpress")
         assert(podName.indexOf("wp-nginx") > -1);
     });
     it('should find wordpresssite campus', async () => {
         const kc = new KubeConfig();
         kc.loadFromDefault();
-        const sites = await getSiteListFromKubernetes("svc0041t-wordpress");
-        expect(sites.find(site => site.url == 'https://wpn-test.epfl.ch/campus/restaurants-shops-hotels')).not.be.undefined;
+        const sites = await getSiteListFromKubernetes("svc0041p-wordpress");
+        expect(sites.find(site => site.url == 'https://www.epfl.ch/campus/restaurants-shops-hotels')).not.be.undefined;
     });
 });

--- a/test/unit/kubernetesClient.ts
+++ b/test/unit/kubernetesClient.ts
@@ -1,17 +1,11 @@
 import {KubeConfig} from "@kubernetes/client-node";
-import {getK8SPodName, getSiteListFromKubernetes} from "../../src/utils/source";
+import {getSiteListFromKubernetes} from "../../src/utils/source";
 import {assert, expect} from "chai";
 
 describe('Kubernetes Client Test', () => {
     it('should initialize KubeConfig', () => {
         const kc = new KubeConfig();
         kc.loadFromDefault();
-    });
-    it('should find wp-nginx pod', async () => {
-        const kc = new KubeConfig();
-        kc.loadFromDefault();
-        const podName = await getK8SPodName("svc0041p-wordpress")
-        assert(podName.indexOf("wp-nginx") > -1);
     });
     it('should find wordpresssite campus', async () => {
         const kc = new KubeConfig();

--- a/test/unit/siteTreeTest.ts
+++ b/test/unit/siteTreeTest.ts
@@ -39,12 +39,9 @@ describe("Site Tree", function() {
             const parent : MenuEntry = MenuEntry.parse(new Site('http://toto.com/'), {ID: 1, menu_item_parent: 0, title: "Some_Page parent 1",rest_url: "/wp-json/bla?bla", ...bogusWpMenu}),
                 child : MenuEntry = MenuEntry.parse(new Site('http://toto.com/'), {ID: 2, menu_item_parent: 1, title: "Some_Page child 1",rest_url: "/wp-json/bla?bla", ...bogusWpMenu});
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "http://toto.com/wp-json/bla?bla", entries: [parent, child] }]);
-            const tree = siteTree.getParent("http://toto.com/wp-json/bla?bla",2);
-            if (tree) {
-                assert.equal(tree["http://toto.com/wp-json/bla?bla"].ID, 1);
-            } else {
-                assert.fail();
-            }
+            const found = siteTree.getParent("http://toto.com/wp-json/bla?bla", 2);
+            assert.equal(found!.urlInstanceRestUrl, "http://toto.com/wp-json/bla?bla");
+            assert.equal(found!.entry.ID, 1);
         })
         it("has a child", function() {
             const parent : MenuEntry = MenuEntry.parse(new Site('http://toto.com/'), {ID: 1, menu_item_parent: 0, title: "Some_Page parent 1", rest_url: "/wp-json/bla?bla",...bogusWpMenu}),
@@ -57,30 +54,18 @@ describe("Site Tree", function() {
                 child : MenuEntry = MenuEntry.parse(new Site('http://toto.com/'), {ID: 2, menu_item_parent: 3, title: "Some_Page child 1",rest_url: "/wp-json/bla?bla",  ...bogusWpMenu});
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: [parent, child] }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla",2);
-            if (tree1) {
-                assert.isUndefined(tree1["http://toto.com/wp-json/bla?bla"]);
-            } else {
-                assert.fail();
-            }
+            assert.isUndefined(tree1);
             assert.deepEqual(siteTree.getChildren("https://toto.com/wp-json/bla?bla",1), []);
         })
         it("doesn't crash when entries menu list is undefined", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: undefined }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla",2);
-            if (tree1) {
-                assert.isUndefined(tree1["http://toto.com/wp-json/bla?bla"]);
-            } else {
-                assert.fail();
-            }
+            assert.isUndefined(tree1);
         })
         it("doesn't crash when entries menu list is empty", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: [] }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla",2);
-            if (tree1) {
-                assert.isUndefined(tree1["http://toto.com/wp-json/bla?bla"]);
-            } else {
-                assert.fail();
-            }
+            assert.isUndefined(tree1);
         })
     })
     describe("in multiple sites", function() {
@@ -91,19 +76,14 @@ describe("Site Tree", function() {
                 child2 : MenuEntry = MenuEntry.parse(new Site('http://tototata.com/'), {ID: 3, menu_item_parent: 1 ,title: "Some_Page child 3",rest_url: "/wp-json/bla?bla", ...bogusWpMenu});
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: [parent, child] },{ urlInstanceRestUrl: "https://tototata.com/wp-json/bla?bla", entries: [parent2, child2] }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla", 2);
+            assert.equal(tree1!.urlInstanceRestUrl,
+                "https://toto.com/wp-json/bla?bla");
+            assert.equal(tree1!.entry.title, "Some_Page parent 1");
+
             const tree2 = siteTree.getParent("https://tototata.com/wp-json/bla?bla", 3);
-            if (tree1) {
-                assert.equal(tree1["https://toto.com/wp-json/bla?bla"].title,
-                    "Some_Page parent 1");
-            } else {
-                assert.fail();
-            }
-            if (tree2) {
-                assert.equal(tree2["https://tototata.com/wp-json/bla?bla"].title,
-                    "Some_Page parent 1 bis");
-            } else {
-                assert.fail();
-            }
+            assert.equal(tree2!.urlInstanceRestUrl,
+                "https://tototata.com/wp-json/bla?bla");
+            assert.equal(tree2!.entry.title, "Some_Page parent 1 bis");
         })
         it("gets external site reference", function() {
             const parent : MenuEntry = MenuEntry.parse(new Site('http://tototata.com/'), {ID: 1, menu_item_parent: 0, title: "Some_Page parent 1",rest_url: "/wp-json/bla?bla", ...bogusWpMenu}),
@@ -144,18 +124,9 @@ describe("Site Tree", function() {
             const websiteMenu = JSON.parse(jsonWebSite);
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://wp-httpd.epfl.ch/campus/services/wp-json/epfl/v1/menus/top?lang=en", entries: servicesMenu.items.map((i: any) => MenuEntry.parse(new Site(i.ownerSite.url), i)) },
                 { urlInstanceRestUrl: "https://wp-httpd.epfl.ch/campus/services/website/wp-json/epfl/v1/menus/top?lang=en", entries: websiteMenu.items.map((i: any) => MenuEntry.parse(new Site(i.ownerSite.url), i)) }]);
-            let firstSite: { [urlInstance: string]: MenuEntry } | undefined = siteTree.findItemByUrl("https://wp-httpd/campus/services/website/close-a-website/");
-            if (firstSite) {
-                const restUrl = Object.keys(firstSite)[0];
-                if (firstSite[restUrl]) {
-                    assert.equal(firstSite[restUrl].ID,
-                        24813);
-                } else {
-                    assert.fail();
-                }
-            } else {
-                assert.fail();
-            }
+            let firstSite = siteTree.findItemByUrl("https://wp-httpd/campus/services/website/close-a-website/");
+            assert(firstSite);
+            assert.equal(firstSite.entry.ID, 24813);
         })
     })
 });

--- a/test/unit/siteTreeTest.ts
+++ b/test/unit/siteTreeTest.ts
@@ -41,7 +41,7 @@ describe("Site Tree", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "http://toto.com/wp-json/bla?bla", entries: [parent, child] }]);
             const tree = siteTree.getParent("http://toto.com/wp-json/bla?bla",2);
             if (tree) {
-                assert(tree["http://toto.com/wp-json/bla?bla"].ID === 1);
+                assert.equal(tree["http://toto.com/wp-json/bla?bla"].ID, 1);
             } else {
                 assert.fail();
             }
@@ -58,7 +58,7 @@ describe("Site Tree", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: [parent, child] }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla",2);
             if (tree1) {
-                assert(tree1["http://toto.com/wp-json/bla?bla"] === undefined);
+                assert.isUndefined(tree1["http://toto.com/wp-json/bla?bla"]);
             } else {
                 assert.fail();
             }
@@ -68,7 +68,7 @@ describe("Site Tree", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: undefined }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla",2);
             if (tree1) {
-                assert(tree1["http://toto.com/wp-json/bla?bla"] === undefined);
+                assert.isUndefined(tree1["http://toto.com/wp-json/bla?bla"]);
             } else {
                 assert.fail();
             }
@@ -77,7 +77,7 @@ describe("Site Tree", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: [] }]);
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla",2);
             if (tree1) {
-                assert(tree1["http://toto.com/wp-json/bla?bla"] === undefined);
+                assert.isUndefined(tree1["http://toto.com/wp-json/bla?bla"]);
             } else {
                 assert.fail();
             }
@@ -93,12 +93,14 @@ describe("Site Tree", function() {
             const tree1 = siteTree.getParent("https://toto.com/wp-json/bla?bla", 2);
             const tree2 = siteTree.getParent("https://tototata.com/wp-json/bla?bla", 3);
             if (tree1) {
-                assert(tree1["https://toto.com/wp-json/bla?bla"].title === "Some_Page parent 1");
+                assert.equal(tree1["https://toto.com/wp-json/bla?bla"].title,
+                    "Some_Page parent 1");
             } else {
                 assert.fail();
             }
             if (tree2) {
-                assert(tree2["https://tototata.com/wp-json/bla?bla"].title === "Some_Page parent 1 bis");
+                assert.equal(tree2["https://tototata.com/wp-json/bla?bla"].title,
+                    "Some_Page parent 1 bis");
             } else {
                 assert.fail();
             }
@@ -111,7 +113,8 @@ describe("Site Tree", function() {
                 child3 : MenuEntry = MenuEntry.parse(new Site('https://toto.com/'), {ID: 4, menu_item_parent: 1, title: "Some_Page external menu 4", rest_url: "/wp-json/bla?bla", ...bogusExternalWpMenu});
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://toto.com/wp-json/bla?bla", entries: [parent, child] },
                 { urlInstanceRestUrl: "https://tototata.com/wp-json/bla?bla", entries: [parent2, child2, child3] }]);
-            assert(siteTree.findExternalMenuByRestUrl(child3.getFullUrl())?.title=="Some_Page parent 1");
+            assert.equal(siteTree.findExternalMenuByRestUrl(child3.getFullUrl())?.title,
+                "Some_Page parent 1");
         })
         it("gets the correct instance child", function() {
             const jsonServices =  fs.readFileSync('./test/unit/data/services.json', 'utf-8');
@@ -121,7 +124,8 @@ describe("Site Tree", function() {
             const siteTree = SiteTreeReadOnly([{ urlInstanceRestUrl: "https://wp-httpd.epfl.ch/campus/services/wp-json/epfl/v1/menus/top?lang=en", entries: servicesMenu.items.map((i: any) => MenuEntry.parse(new Site(i.ownerSite.url), i)) },
                 { urlInstanceRestUrl: "https://wp-httpd.epfl.ch/campus/services/website/wp-json/epfl/v1/menus/top?lang=en", entries: websiteMenu.items.map((i: any) => MenuEntry.parse(new Site(i.ownerSite.url), i)) }]);
             const children = siteTree.getChildren("https://wp-httpd.epfl.ch/campus/services/wp-json/epfl/v1/menus/top?lang=en", 7119);
-            assert(children.filter(item => item.ID ===15624 ).length == 1);
+            assert.equal(children.filter(item => item.ID ===15624 ).length,
+                1);
         })
         it("has no external menu as children", function() {
             const jsonServices =  fs.readFileSync('./test/unit/data/services.json', 'utf-8');
@@ -144,7 +148,8 @@ describe("Site Tree", function() {
             if (firstSite) {
                 const restUrl = Object.keys(firstSite)[0];
                 if (firstSite[restUrl]) {
-                    assert(firstSite[restUrl].ID ===24813);
+                    assert.equal(firstSite[restUrl].ID,
+                        24813);
                 } else {
                     assert.fail();
                 }


### PR DESCRIPTION
- Define, export and pervasively use a `MenuEntryAndUrl` type in `src/interfaces/siteTree.ts`
- Allow `getParent()` to return undefined (rather than a data structure that one must interpret) in case of no parent
- Eliminate all that business of dicts-with-a-single-key
- Cosmetic changes regarding proper pluralization (`menusEntries` → `menuEntries`; `entries` → `entry` when the associated type is actually a single `MenuEntry`)
- Make test failures easier to interpret
- Remove unused function `getLabOrAssoc()`